### PR TITLE
Fix undefinied reference ld errors

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -15,6 +15,6 @@ shared_library('module',
 	dependencies		: [edje, elm, e],
 	install			: true,
 	install_dir             : dir_mod,
-	link_args		: '-Wl,--unresolved-symbols=ignore-in-object-files',
+	link_args		: '-Wl,--unresolved-symbols=ignore-all',
         name_prefix             : ''
 )


### PR DESCRIPTION
I got ld undefinied reference errors when building on OpenBSD. With this changes builds fine, I use enlightenment's module link_args, like [here](https://git.enlightenment.org/enlightenment/enlightenment/src/commit/928cf22f3e64d6304c7adf3162de34fb3d46c02f/src/modules/meson.build#L129). 

Tested on OpenBSD, ld is ok, build is ok, package runs fine with latest efl, and enlightenment.